### PR TITLE
Add git to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ MAINTAINER louisbl <louis@beltramo.me>
 # Set memory limit
 RUN echo "memory_limit=1024M" > /usr/local/etc/php/conf.d/memory-limit.ini
 
+# Install git
+RUN apt-get update && apt-get install -y --no-install-recommends git
+
 # Install Composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# docker-composer
+Dockerfile for composer


### PR DESCRIPTION
J'ai eu quelques soucis avec composer pour Drupal... L'image n'ayant pas git, composer passe par des fallbacks http qui, en cas d'erreur, font planter le `composer install` (c'est le cas pour certains plugins).

Ça remarche en ajoutant git dans l'image, je te laisse merge la modif ou non, si jamais tu as une meilleure solution.

Bye
